### PR TITLE
Add new commands, Add new settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/5uvu1nmf3js0po7j?svg=true)](https://ci.appveyor.com/project/Ciastex/spectrum)  
 
-### What is Spectrum?
-Spectrum is a simple, yet powerful extension system for Refract Studios' game 
-[Distance](http://survivethedistance.com/)
-It allows you to write custom Lua scripts and DLL plugins to customize the
-game's experience and make it do things the original game's developers didn't 
-even think about. It's being constantly updated by one of the Distance community
-members.
+# Modified ServerMod for Distance
+[Latest Release](https://github.com/Corecii/Spectrum/releases)
+
+This contains a modified version of the ServerMod from [here](https://github.com/larnin/Spectrum).
+
+You need [Spectrum](https://github.com/Ciastex/Spectrum) to use this.
 
 ### Installation
-Please refer to [this Wiki](https://github.com/Ciastex/Spectrum/wiki/Installing-Spectrum) page about Spectrum installation process.
+1. Install Spectrum
+2. Copy `ServerMod.plugin.dll` to `Distance/Distance_Data/Spectrum/Plugins`
 
-### Reporting a Bug
-Please refer to [this Wiki](https://github.com/Ciastex/Spectrum/wiki/Reporting-a-bug) page on how to make a good bug report.
+### Features
+* Auto mode: Run the server through your selected playlist automatically. Pause
+if there are no players. Shuffle the playlist when reaching the end.
+* Autospec: Spectate automatically. Good for auto-hosting servers.
+* Voting: Voting to skip a map, stop the countdown, and play a level with
+configurable vote passing thresholds
+* Welcome message: Show a message to players when they join
+* Manage the current playlist without going to the lobby
+* Stop the 60 second countdown
 
-### Building Spectrum
-Please refer to [this Wiki](https://github.com/Ciastex/Spectrum/wiki/Building-Spectrum-from-source) page on building Spectrum from source.
+---
 
-### Getting unstable versions
-[AppVeyor artifacts](https://ci.appveyor.com/project/Ciastex/spectrum/build/artifacts) page contains the binaries for the latest commit.
-
-### Authors
-Please see AUTHORS.md for details.
-
-### Licensing
-Please see LICENSE.md for details
+## What is [Spectrum](https://github.com/Ciastex/Spectrum)?
+Spectrum is a simple, yet powerful extension system for Refract Studios' game
+[Distance](http://survivethedistance.com/).
+It allows you to write custom Lua scripts and DLL plugins to customize the
+game's experience and make it do things the original game's developers didn't
+even think about. It's being constantly updated by one of the Distance community
+members.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,27 @@
+[![Build status](https://ci.appveyor.com/api/projects/status/5uvu1nmf3js0po7j?svg=true)](https://ci.appveyor.com/project/Ciastex/spectrum)  
 
-# Modified ServerMod for Distance
-[Latest Release](https://github.com/Corecii/Spectrum/releases)
-
-This contains a modified version of the ServerMod from [here](https://github.com/larnin/Spectrum).
-
-You need [Spectrum](https://github.com/Ciastex/Spectrum) to use this.
-
-### Installation
-1. Install Spectrum
-2. Copy `ServerMod.plugin.dll` to `Distance/Distance_Data/Spectrum/Plugins`
-
-### Features
-* Auto mode: Run the server through your selected playlist automatically. Pause
-if there are no players. Shuffle the playlist when reaching the end.
-* Autospec: Spectate automatically. Good for auto-hosting servers.
-* Voting: Voting to skip a map, stop the countdown, and play a level with
-configurable vote passing thresholds
-* Welcome message: Show a message to players when they join
-* Manage the current playlist without going to the lobby
-* Stop the 60 second countdown
-
----
-
-## What is [Spectrum](https://github.com/Ciastex/Spectrum)?
-Spectrum is a simple, yet powerful extension system for Refract Studios' game
-[Distance](http://survivethedistance.com/).
+### What is Spectrum?
+Spectrum is a simple, yet powerful extension system for Refract Studios' game 
+[Distance](http://survivethedistance.com/)
 It allows you to write custom Lua scripts and DLL plugins to customize the
-game's experience and make it do things the original game's developers didn't
+game's experience and make it do things the original game's developers didn't 
 even think about. It's being constantly updated by one of the Distance community
 members.
+
+### Installation
+Please refer to [this Wiki](https://github.com/Ciastex/Spectrum/wiki/Installing-Spectrum) page about Spectrum installation process.
+
+### Reporting a Bug
+Please refer to [this Wiki](https://github.com/Ciastex/Spectrum/wiki/Reporting-a-bug) page on how to make a good bug report.
+
+### Building Spectrum
+Please refer to [this Wiki](https://github.com/Ciastex/Spectrum/wiki/Building-Spectrum-from-source) page on building Spectrum from source.
+
+### Getting unstable versions
+[AppVeyor artifacts](https://ci.appveyor.com/project/Ciastex/spectrum/build/artifacts) page contains the binaries for the latest commit.
+
+### Authors
+Please see AUTHORS.md for details.
+
+### Licensing
+Please see LICENSE.md for details

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -171,6 +171,7 @@ namespace Spectrum.Plugins.ServerMod
             {
                 PlayCMD.playersCanAddMap = (bool)Settings["playersCanAddMap"];
                 PlayCMD.addOneMapOnly = (bool)Settings["addOneMapOnly"];
+                PlayCMD.useVote = (bool)Settings["playIsVote"];
 
                 VoteHandler.VoteCMD.votesAllowed = (bool)Settings["allowVoteSystem"];
                 if (Settings.ContainsKey("voteSystemThresholds") && VoteHandler.thresholds != null)
@@ -208,6 +209,7 @@ namespace Spectrum.Plugins.ServerMod
         {
             Settings["playersCanAddMap"] = PlayCMD.playersCanAddMap;
             Settings["addOneMapOnly"] = PlayCMD.addOneMapOnly;
+            Settings["playIsVote"] = PlayCMD.useVote;
 
             Settings["allowVoteSystem"] = VoteHandler.VoteCMD.votesAllowed;
             if (VoteHandler.thresholds != null)
@@ -235,6 +237,8 @@ namespace Spectrum.Plugins.ServerMod
                 Settings["playersCanAddMap"] = false;
             if (!Settings.ContainsKey("addOneMapOnly"))
                 Settings["addOneMapOnly"] = true;
+            if (!Settings.ContainsKey("playIsVote"))
+                Settings["playIsVote"] = false;
 
             if (!Settings.ContainsKey("allowVoteSystem"))
                 Settings["allowVoteSystem"] = false;

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -16,7 +16,7 @@ namespace Spectrum.Plugins.ServerMod
         public string Author => "Nico";
         public string Contact => "SteamID: larnin";
         public APILevel CompatibleAPILevel => APILevel.UltraViolet;
-        public string PluginVersion = "Version C.0.5.3";
+        public string PluginVersion = "V0.5.0";
 
         private static Settings Settings = new Settings(typeof(Entry));
 

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -16,7 +16,7 @@ namespace Spectrum.Plugins.ServerMod
         public string Author => "Nico";
         public string Contact => "SteamID: larnin";
         public APILevel CompatibleAPILevel => APILevel.UltraViolet;
-        public string PluginVersion = "V0.4";
+        public string PluginVersion = "Version C.0.5.0";
 
         private static Settings Settings = new Settings(typeof(Entry));
 
@@ -171,9 +171,30 @@ namespace Spectrum.Plugins.ServerMod
             {
                 PlayCMD.playersCanAddMap = (bool)Settings["playersCanAddMap"];
                 PlayCMD.addOneMapOnly = (bool)Settings["addOneMapOnly"];
+
+                VoteHandler.VoteCMD.votesAllowed = (bool)Settings["allowVoteSystem"];
+                if (Settings.ContainsKey("voteSystemThresholds") && VoteHandler.thresholds != null)
+                {
+                    foreach (KeyValuePair<string, double> entry in (Dictionary<string, double>)Settings["voteSystemThresholds"])
+                    {
+                        VoteHandler.thresholds[entry.Key] = entry.Value;
+                    }
+                }
+
+                AutoSpecCMD.autoSpecReturnToLobby = (bool)Settings["autoSpecReturnToLobby"];
+
+                WelcomeCMD.welcomeMessage = (string)Settings["welcome"];
+
+                AutoCMD.autoSpecCountsAsPlayer = (bool)Settings["autoSpecCountsAsPlayer"];
                 AutoCMD.voteNext = (bool)Settings["voteNext"];
+                AutoCMD.advanceMessage = (string)Settings["autoAdvanceMsg"];
+                AutoCMD.minPlayers = (int)Settings["autoMinPlayers"];
+                AutoCMD.maxRunTime = (int)Settings["autoMaxTime"];
+
                 WinCMD.winList = ((string[])Settings["win"]).ToList();
                 RipCMD.ripList = ((string[])Settings["rip"]).ToList();
+
+
             }
             catch (Exception e)
             {
@@ -187,7 +208,23 @@ namespace Spectrum.Plugins.ServerMod
         {
             Settings["playersCanAddMap"] = PlayCMD.playersCanAddMap;
             Settings["addOneMapOnly"] = PlayCMD.addOneMapOnly;
+
+            Settings["allowVoteSystem"] = VoteHandler.VoteCMD.votesAllowed;
+            if (VoteHandler.thresholds != null)
+            {
+                Settings["voteSystemThresholds"] = VoteHandler.thresholds;
+            }
+
+            Settings["autoSpecReturnToLobby"] = AutoSpecCMD.autoSpecReturnToLobby;
+
+            Settings["welcome"] = WelcomeCMD.welcomeMessage;
+
+            Settings["autoSpecCountsAsPlayer"] = AutoCMD.autoSpecCountsAsPlayer;
             Settings["voteNext"] = AutoCMD.voteNext;
+            Settings["autoAdvanceMsg"] = AutoCMD.advanceMessage;
+            Settings["autoMinPlayers"] = AutoCMD.minPlayers;
+            Settings["autoMaxTime"] = AutoCMD.maxRunTime;
+
 
             Settings.Save();
         }
@@ -198,8 +235,26 @@ namespace Spectrum.Plugins.ServerMod
                 Settings["playersCanAddMap"] = false;
             if (!Settings.ContainsKey("addOneMapOnly"))
                 Settings["addOneMapOnly"] = true;
+
+            if (!Settings.ContainsKey("allowVoteSystem"))
+                Settings["allowVoteSystem"] = false;
+
+            if (!Settings.ContainsKey("autoSpecReturnToLobby"))
+                Settings["autoSpecReturnToLobby"] = false;
+
+            if (!Settings.ContainsKey("welcome"))
+                Settings["welcome"] = "";
             if (!Settings.ContainsKey("voteNext"))
                 Settings["voteNext"] = false;
+            if (!Settings.ContainsKey("autoAdvanceMsg"))
+                Settings["autoAdvanceMsg"] = "";
+            if (!Settings.ContainsKey("autoMinPlayers"))
+                Settings["autoMinPlayers"] = 2;
+            if (!Settings.ContainsKey("autoMaxTime"))
+                Settings["autoMaxTime"] = 15*60;
+            if (!Settings.ContainsKey("autoSpecCountsAsPlayer"))
+                Settings["autoSpecCountsAsPlayer"] = false;
+
             if (!Settings.ContainsKey("win"))
                 Settings["win"] = WinCMD.winList;
             if (!Settings.ContainsKey("rip"))

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -249,7 +249,7 @@ namespace Spectrum.Plugins.ServerMod
             if (!Settings.ContainsKey("autoAdvanceMsg"))
                 Settings["autoAdvanceMsg"] = "";
             if (!Settings.ContainsKey("autoMinPlayers"))
-                Settings["autoMinPlayers"] = 2;
+                Settings["autoMinPlayers"] = 1;
             if (!Settings.ContainsKey("autoMaxTime"))
                 Settings["autoMaxTime"] = 15*60;
             if (!Settings.ContainsKey("autoSpecCountsAsPlayer"))

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -16,7 +16,7 @@ namespace Spectrum.Plugins.ServerMod
         public string Author => "Nico";
         public string Contact => "SteamID: larnin";
         public APILevel CompatibleAPILevel => APILevel.UltraViolet;
-        public string PluginVersion = "V0.5.0";
+        public string PluginVersion = "V0.5";
 
         private static Settings Settings = new Settings(typeof(Entry));
 

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -16,7 +16,7 @@ namespace Spectrum.Plugins.ServerMod
         public string Author => "Nico";
         public string Contact => "SteamID: larnin";
         public APILevel CompatibleAPILevel => APILevel.UltraViolet;
-        public string PluginVersion = "Version C.0.5.0";
+        public string PluginVersion = "Version C.0.5.3";
 
         private static Settings Settings = new Settings(typeof(Entry));
 

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -16,7 +16,7 @@ namespace Spectrum.Plugins.ServerMod
         public string Author => "Corecii";
         public string Contact => "SteamID: Corecii; Discord: Corecii#3019";
         public APILevel CompatibleAPILevel => APILevel.UltraViolet;
-        public string PluginVersion = "Version C.0.5.4";
+        public string PluginVersion = "Version C.0.5.5";
 
         private static Settings Settings = new Settings(typeof(Entry));
 

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -13,10 +13,10 @@ namespace Spectrum.Plugins.ServerMod
     public class Entry : IPlugin
     {
         public string FriendlyName => "Server commands Mod";
-        public string Author => "Nico";
-        public string Contact => "SteamID: larnin";
+        public string Author => "Corecii";
+        public string Contact => "SteamID: Corecii; Discord: Corecii#3019";
         public APILevel CompatibleAPILevel => APILevel.UltraViolet;
-        public string PluginVersion = "Version C.0.5.3";
+        public string PluginVersion = "Version C.0.5.4";
 
         private static Settings Settings = new Settings(typeof(Entry));
 

--- a/Spectrum.Plugins.ServerMod/Entry.cs
+++ b/Spectrum.Plugins.ServerMod/Entry.cs
@@ -186,7 +186,7 @@ namespace Spectrum.Plugins.ServerMod
 
                 WelcomeCMD.welcomeMessage = (string)Settings["welcome"];
 
-                AutoCMD.autoSpecCountsAsPlayer = (bool)Settings["autoSpecCountsAsPlayer"];
+                AutoCMD.autoSpecHostIgnored = (bool)Settings["autoSpecHostIgnored"];
                 AutoCMD.voteNext = (bool)Settings["voteNext"];
                 AutoCMD.advanceMessage = (string)Settings["autoAdvanceMsg"];
                 AutoCMD.minPlayers = (int)Settings["autoMinPlayers"];
@@ -221,7 +221,7 @@ namespace Spectrum.Plugins.ServerMod
 
             Settings["welcome"] = WelcomeCMD.welcomeMessage;
 
-            Settings["autoSpecCountsAsPlayer"] = AutoCMD.autoSpecCountsAsPlayer;
+            Settings["autoSpecHostIgnored"] = AutoCMD.autoSpecHostIgnored;
             Settings["voteNext"] = AutoCMD.voteNext;
             Settings["autoAdvanceMsg"] = AutoCMD.advanceMessage;
             Settings["autoMinPlayers"] = AutoCMD.minPlayers;
@@ -256,8 +256,20 @@ namespace Spectrum.Plugins.ServerMod
                 Settings["autoMinPlayers"] = 1;
             if (!Settings.ContainsKey("autoMaxTime"))
                 Settings["autoMaxTime"] = 15*60;
-            if (!Settings.ContainsKey("autoSpecCountsAsPlayer"))
-                Settings["autoSpecCountsAsPlayer"] = false;
+            if (!Settings.ContainsKey("autoSpecHostIgnored"))
+            {
+                if (Settings.ContainsKey("autoSpecCountsAsPlayer"))
+                {
+                    // this setting was renamed from `autoSpecCountsAsPlayer`
+                    //  to `autoSpecHostIgnored` for clarity
+                    Settings["autoSpecHostIgnored"] = !(bool)Settings["autoSpecCountsAsPlayer"];
+                    Settings.Remove("autoSpecCountsAsPlayer");
+                }
+                else
+                {
+                    Settings["autoSpecHostIgnored"] = true;
+                }
+            }
 
             if (!Settings.ContainsKey("win"))
                 Settings["win"] = WinCMD.winList;

--- a/Spectrum.Plugins.ServerMod/Readme.md
+++ b/Spectrum.Plugins.ServerMod/Readme.md
@@ -81,11 +81,6 @@ Commands with "(L)" can only be used by the local player (the one who has the pl
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!help [command name]  
 Shows the help message of the specified command.
 
-#### Welcome:
-Permission: __ALL__  
-Use: !welcome  
-Shows the welcome message again  
-
 #### Level:
 Permission: __ALL__  (can also be used as client)  
 Use: !level [keyword]  
@@ -121,32 +116,6 @@ The filter works exactly like the list command.
 If the `play` setting is true, players can add levels directly, one at a time.  
 If the `playVote` setting is true, players can vote for multiple levels at once: `!play <level>` will act as an alias for `!vote y play <level>`  
 `playVote` overrides `play`. The host will keep the default functionality for the `!play` command, always.
-
-#### Vote:
-Permission: __ALL__
-Use: !vote [y/n/i] [vote type] [value]
-Allows voting for various things, with configurable passing thresholds:
-* `!vote [y/n/i] skip` Vote to skip the current level
-* `!vote [y/n/i] stop` Vote to stop the countdown
-* `!vote [y/n/i] play [level name]` Vote to play a map
-`[y/n/i]` can be left off, and the vote is done as a `yes` vote:
-* `!vote skip` is `!vote y skip`
-* `!vote play <map>` is `!vote y play <map>`
-
-##### Examples:
-`!vote skip` Vote to skip the current level  
-`!vote y skip` Vote to skip the current level  
-`!vote n skip` Cancel your vote to skip the level  
-`!vote i stop` View the vote pass threshold, votes made, and votes needed to stop the countdown  
-`!vote play inferno` Vote to play the level "Inferno"  
-`!vote play -a krispy` Vote to play all of Krispy's maps  
-Votes for maps are counted individually for every map, not by the command used.  
-
-#### VoteCtrl:
-Permission: __HOST__  
-Use: !votectrl [vote type] [percent]  
-Vote types are `skip`, `stop`, and `play`.  
-`percent` should be a number between 0 and 100. Numbers above 100 effectively disable the vote.  
 
 #### Playlist:
 Permission: __ALL__  
@@ -238,6 +207,37 @@ Permission: __HOST__
 Use: !timelimit [value]  
 Works like the official command, it changes the max time for the next reverse tag maps.  
 The value must be between 30 and 1800 seconds (30 minutes)
+
+#### Vote:
+Permission: __ALL__
+Use: !vote [y/n/i] [vote type] [value]
+Allows voting for various things, with configurable passing thresholds:
+* `!vote [y/n/i] skip` Vote to skip the current level
+* `!vote [y/n/i] stop` Vote to stop the countdown
+* `!vote [y/n/i] play [level name]` Vote to play a map
+`[y/n/i]` can be left off, and the vote is done as a `yes` vote:
+* `!vote skip` is `!vote y skip`
+* `!vote play <map>` is `!vote y play <map>`
+
+##### Examples:
+`!vote skip` Vote to skip the current level  
+`!vote y skip` Vote to skip the current level  
+`!vote n skip` Cancel your vote to skip the level  
+`!vote i stop` View the vote pass threshold, votes made, and votes needed to stop the countdown  
+`!vote play inferno` Vote to play the level "Inferno"  
+`!vote play -a krispy` Vote to play all of Krispy's maps  
+Votes for maps are counted individually for every map, not by the command used.  
+
+#### VoteCtrl:
+Permission: __HOST__  
+Use: !votectrl [vote type] [percent]  
+Vote types are `skip`, `stop`, and `play`.  
+`percent` should be a number between 0 and 100. Numbers above 100 effectively disable the vote.  
+
+#### Welcome:
+Permission: __ALL__  
+Use: !welcome  
+Shows the welcome message again  
 
 #### Win
 Permission: __ALL__  

--- a/Spectrum.Plugins.ServerMod/Readme.md
+++ b/Spectrum.Plugins.ServerMod/Readme.md
@@ -76,7 +76,7 @@ Use: !level [keyword]
 Shows all levels in the host’s library that contain the entered keyword.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!level [filter]  
 Shows all levels that match the filter.  
-See bellow for more information about filters.  
+See below for more information about filters.  
 If this command is used as a client with __%level__, it search on your library.
 
 #### List:

--- a/Spectrum.Plugins.ServerMod/Readme.md
+++ b/Spectrum.Plugins.ServerMod/Readme.md
@@ -117,7 +117,10 @@ Adds a level to the playlist in the first position (the next level to be played)
 If more than one level matches the name exactly, the first one is added.  
 If only one level contains the name, it will be added to the playlist.  
 If more than one level contains the name, it will display the matching levels (like !level).  
-The filter works exactly like the list command.
+The filter works exactly like the list command.  
+If the `play` setting is true, players can add levels directly, one at a time.  
+If the `playVote` setting is true, players can vote for multiple levels at once: `!play <level>` will act as an alias for `!vote y play <level>`  
+`playVote` overrides `play`. The host will keep the default functionality for the `!play` command, always.
 
 #### Vote:
 Permission: __ALL__
@@ -126,13 +129,17 @@ Allows voting for various things, with configurable passing thresholds:
 * `!vote [y/n/i] skip` Vote to skip the current level
 * `!vote [y/n/i] stop` Vote to stop the countdown
 * `!vote [y/n/i] play [level name]` Vote to play a map
+`[y/n/i]` can be left off, and the vote is done as a `yes` vote:
+* `!vote skip` is `!vote y skip`
+* `!vote play <map>` is `!vote y play <map>`
 
 ##### Examples:
+`!vote skip` Vote to skip the current level  
 `!vote y skip` Vote to skip the current level  
 `!vote n skip` Cancel your vote to skip the level  
 `!vote i stop` View the vote pass threshold, votes made, and votes needed to stop the countdown  
-`!vote y play inferno` Vote to play the level "Inferno"  
-`!vote y play -a krispy` Vote to play all of Krispy's maps  
+`!vote play inferno` Vote to play the level "Inferno"  
+`!vote play -a krispy` Vote to play all of Krispy's maps  
 Votes for maps are counted individually for every map, not by the command used.  
 
 #### VoteCtrl:
@@ -184,6 +191,10 @@ Changes the name of the server.
 Permission: __HOST__  
 Use: !settings reload  
 Reloads the settings from file.  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings playVote [true/false]  
+Allows players to vote for maps on the playlist with the __!play__ command.  
+If true, __!play <map>__ acts as an alias for `!vote y play <map>`  
+The host keeps the regular functionality of __!play__.
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings play [true/false]  
 Allows players to add maps on the playlist with the __!play__ command.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings addOne [true/false]  
@@ -286,6 +297,9 @@ When the plugin is started for the first time, it generate a setting file that l
 ```
 __playersCanAddMap__ (true/false): Allows players to add map on the playlist.  
 You can change it with the command !settings play.  
+__playIsVote__ (true/false): Turns `!play <map>` into `!vote y play <map>` for non-hosts.  
+You can change it with the command !settings playVote.
+The host always keeps the regular functionality of !play.
 __addOneMapOnly__ (true/false): If players are allowed to add map and this option set to true, they can only add one map at a time.  
 You can change it with the command !settings addOne.  
 __allowVoteSystem__ (true/false): Allows the !vote command to be used.  

--- a/Spectrum.Plugins.ServerMod/Readme.md
+++ b/Spectrum.Plugins.ServerMod/Readme.md
@@ -2,7 +2,7 @@
 
 Spectrum.Plugins.ServerMod is a plugin that adds some commands to the server, accessible by the host and players.  
 All the commands are prefixed by '!'.  
-If you are a client and you have the plugin, you can use some of your commands by remplacing the '!' key to '%'  
+If you are a client and you have the plugin, you can use some of your commands by replacing the '!' key to '%'.
 
 Commands have 3 permission levels:
 * __HOST__: Only the host can use the command
@@ -11,7 +11,7 @@ Commands have 3 permission levels:
 
 Some commands with __ALL__ permission level can also be used as a client.  
 
-__Playlist managing commands can't be used on trackmogrify mode (trackmogrify don't use playlist).__ 
+__Playlist managing commands can't be used on trackmogrify mode (trackmogrify doesn't use playlists).__
 
 # Command list (alphabetized):
 
@@ -21,15 +21,20 @@ Use: !auto
 Toggle the server auto mode.  
 When auto mode is activated, the server will automatically jump to the next level when all players finish.  
 If a level lasts longer than 15 minutes, the server continues to the next level.  
-If the playlist ends, the server shuffle the playlist automatically.  
+The maximum time on a level can be configured with the `autoMaxTime` settings.  
+If the playlist ends, the server shuffles the playlist automatically.  
 Auto mode doesn't work with Trackmogrify.  
-At the end of a map, if votes are enabled, players can choose between the 3 next maps (or restart the current) on the playlist the one they wants to play next.
+At the end of a map, if votes are enabled, players can choose between the 3 next maps (or restart the current) on the playlist the one they wants to play next.  
+If there are not enough players, the server will wait for players to join.  
+The minimum players is configurable with the `autoMinPlayers` setting.
+
 
 #### Autospec:
 Permission: __LOCAL__  
 Use: !autospec  
 Toggles automatic spectating (useful when you go AFK or use auto mode).  
-If you are the host and no players are online, the server will automatically return to the lobby.
+If the setting `autoSpecReturnToLobby` in the settings file is `true`: If you are the host and no players are online, the server will automatically return to the lobby.  
+By default, `autoSpecReturnToLobby` is `false`.
 
 #### Clear:
 Permission: __HOST__  
@@ -53,7 +58,13 @@ Shows the date and time of the owner of the plugin.
 #### Del:
 Permission: __HOST__  
 Use: !del [index]  
-Removes the map at the entered index for the current playlist.  
+Removes the map at the entered index from the current playlist.  
+The next map has an index of 1.
+
+#### Dels:
+Permission: __HOST__  
+Use: !dels [indexStart] [indexEnd]
+Removes the maps between the entered start and end indexes from the current playlist.  
 The next map has an index of 1.
 
 #### ForceStart:
@@ -69,6 +80,11 @@ Commands with "(H)" can only be used by the host.
 Commands with "(L)" can only be used by the local player (the one who has the plugin).  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!help [command name]  
 Shows the help message of the specified command.
+
+#### Welcome:
+Permission: __ALL__  
+Use: !welcome  
+Shows the welcome message again  
 
 #### Level:
 Permission: __ALL__  (can also be used as client)  
@@ -91,7 +107,7 @@ Shows all the available playlists.
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!load [playlist name]  
 Removes all the levels on the current playlist and load a new one.  
 If you are not on the lobby, the current level is added at the start of the new playlist.
-    
+
 #### Play:
 Permission: __HOST__  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;__ALL__ (if players can add maps)  
@@ -102,6 +118,28 @@ If more than one level matches the name exactly, the first one is added.
 If only one level contains the name, it will be added to the playlist.  
 If more than one level contains the name, it will display the matching levels (like !level).  
 The filter works exactly like the list command.
+
+#### Vote:
+Permission: __ALL__
+Use: !vote [y/n/i] [vote type] [value]
+Allows voting for various things, with configurable passing thresholds:
+* `!vote [y/n/i] skip` Vote to skip the current level
+* `!vote [y/n/i] stop` Vote to stop the countdown
+* `!vote [y/n/i] play [level name]` Vote to play a map
+
+##### Examples:
+`!vote y skip` Vote to skip the current level  
+`!vote n skip` Cancel your vote to skip the level  
+`!vote i stop` View the vote pass threshold, votes made, and votes needed to stop the countdown  
+`!vote y play inferno` Vote to play the level "Inferno"  
+`!vote y play -a krispy` Vote to play all of Krispy's maps  
+Votes for maps are counted individually for every map, not by the command used.  
+
+### VoteCtrl:
+Permission: __HOST__  
+Use: !votectrl [vote type] [percent]  
+Vote types are `skip`, `stop`, and `play`.  
+`percent` should be a number between 0 and 100. Numbers above 100 effectively disable the vote.  
 
 #### Playlist:
 Permission: __ALL__  
@@ -123,7 +161,7 @@ Prints a losing sentence.
 Permission: __HOST__  
 Use: !save [name]  
 Save the current playlist on a file on the game playlist directory.  
-It can be loaded agains with the __!load__ command, or on the lobby.  
+It can be loaded again with the __!load__ command, or o=in the lobby.  
 
 #### Scores:
 Permission: __ALL__ (can also be used as client)  
@@ -146,13 +184,32 @@ Changes the name of the server.
 Permission: __HOST__  
 Use: !settings reload  
 Reloads the settings from file.  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings vote [true/false]  
-Allows players to vote for the next map on auto mode.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings play [true/false]  
 Allows players to add maps on the playlist with the __!play__ command.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings addOne [true/false]  
-If players can add maps and this option enabled, the players can only add one map at a time .
-    
+If players can add maps and this option enabled, the players can only add one map at a time.  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings welcome [message]  
+Sets a welcome message to display to entering players.  
+In the message, %USERNAME% is replace by the player's name.  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings voteSystem [true/false]  
+Turn the `!vote` command on or off.  
+You can control vote thresholds with `!votectrl`  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoVote [true/false]  
+Allows players to vote for the next map on auto mode.  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoMsg [message]  
+Sets a message to display when advancing to the next track.  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoMinPlayers [amount]  
+Sets the minimum amount of players for auto mode to advance to the next map.  
+If the host is autospectating and `autoSpecPlayer` is false, this number will internally increase by 1 to simulate the host not being present.  
+Default: 1  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoMaxTime [seconds]  
+Sets the maximum amount of seconds to run each level for.  
+Default: 900 (15 minutes)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoSpecPlayer [true/false]  
+Whether or not the host counts as a player for `autoMinPlayers` when spectating.  
+If false, one more player is required to go to the next level.  
+Default: false  
+
 #### Shuffle:
 Permission: __HOST__  
 Use: !shuffle  
@@ -179,7 +236,7 @@ Prints a random winning sentence.
 # Filters
 Commands __level__ and __play__ can use filters to allow you to search maps.
 * __-name__ or __-n__ : Select maps that contains theses words on it's name.
-* __-author__ or __-a__ : Only show you maps form the entred author 
+* __-author__ or __-a__ : Only show you maps form the entred author
 * __-mode__ or __-m__ : Select map on one particular gamemode. If not specified, it use the current gamemode
     * Valid gamemodes are : sprint, challenge, tag, soccer, style, stun  
     _(Soccer mode don't work perfectly)_
@@ -196,11 +253,26 @@ __!play -name up -mode challenge -index 1__ : Add the first level from challenge
 __!level -last -p 4__ : Shows the 4th page (result 30 to 39) of the last command.
 
 # Settings
-When the plugin is started for the first time, it generate a setting file that look like this : (on json)
+When the plugin is started for the first time, it generate a setting file that look like this : (in json)
 ```
 {
-	"playersCanAddMap" : true,
+	"playersCanAddMap" : false,
 	"addOneMapOnly" : true,
+	"allowVoteSystem" : false,
+	"autoSpecReturnToLobby" : false,
+	"welcome" : "",
+	"voteNext" : false,
+	"autoAdvanceMsg" : "",
+	"autoMinPlayers" : 1,
+	"autoMaxTime" : 900,
+	"autoSpecCountsAsPlayer" : false,
+	"voteSystemThresholds" : {
+		"skip" : 0.7,
+		"stop" : 0.7,
+		"play" : 0.55,
+		"kick" : 0.9,
+		"count" : 0.55
+	},
 	"win" : [
 		"ALL RIGHT!",
 		"YEAH!"
@@ -209,21 +281,36 @@ When the plugin is started for the first time, it generate a setting file that l
 		"ACCESS VIOLATION!",
 		"AW, THAT'S TOO BAD!",
 		"YOU'RE OUT OF CONTROL!"
-	],
-	"voteNext" : true
+	]
 }
 ```
 __playersCanAddMap__ (true/false): Allows players to add map on the playlist.  
 You can change it with the command !settings play.  
 __addOneMapOnly__ (true/false): If players are allowed to add map and this option set to true, they can only add one map at a time.  
 You can change it with the command !settings addOne.  
+__allowVoteSystem__ (true/false): Allows the !vote command to be used.  
+You can change it with the command !settings voteSystem  
+__autpSpecReturnToLobby__ (true/false): Whether or not the host returns to lobby when they are the last player and are auto-spectating.  
+__welcome__ (text): The message to display to players that enter. If empty, no message is displayed.  
+You can change it with the command !settings welcome  
+%USERNAME% is replaced by the player's name. \\n represents a new line. \\" allows you to put in quotes.  
 __voteNext__ (true/false): Allows players to vote for the next map on auto mode.  
 You can change it with the command !settings vote.  
+__autoAdvanceMsg__ (text): The message to display in auto mode when going to the next level. No message if empty.  
+You can change it with the command !settings autoMsg  
+__autoMinPlayers__ (number): The minimum amount of players needed for auto mode to go to the next level.  
+You can change it with the command !settings autoMinPlayers  
+__autoMaxTime__ (seconds): The maximum amount of time auto mode will spend on one level.  
+You can change it with the command !settings autoMaxTime  
+__autoSpecCountsAsPlayer__ (true/false): Whether or not the host counts towards autoMinPlayers if they are auto-spectating.  
+You can change it with the command !settings autoSpecPlayer  
+__voteSystemThresholds__: The vote pass thresholds for each type of vote.  
+You can change them with the command !votectrl [vote type] [new threshold from 0 to 100]  
+When using the !votectrl command, the threshold should be a number, no decimals, from 0 to 100.  
+55 in !votectrl is the same as .55 in the settings file.  
 __win__ (list of string): A list of sentence that will be picked randomly when a player use the command !win  
 __rip__ (list of string) : A list of sentence that will be picked randomly when a player use the command !rip  
 
-# Author contacts 
+# Author contacts
 Steam : http://steamcommunity.com/id/larnin/  
 Discord : Nico#5480 (https://discord.gg/0SlqqvzfIbi6zhbY)
-
-

--- a/Spectrum.Plugins.ServerMod/Readme.md
+++ b/Spectrum.Plugins.ServerMod/Readme.md
@@ -135,7 +135,7 @@ Allows voting for various things, with configurable passing thresholds:
 `!vote y play -a krispy` Vote to play all of Krispy's maps  
 Votes for maps are counted individually for every map, not by the command used.  
 
-### VoteCtrl:
+#### VoteCtrl:
 Permission: __HOST__  
 Use: !votectrl [vote type] [percent]  
 Vote types are `skip`, `stop`, and `play`.  

--- a/Spectrum.Plugins.ServerMod/Readme.md
+++ b/Spectrum.Plugins.ServerMod/Readme.md
@@ -185,10 +185,9 @@ Default: 1
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoMaxTime [seconds]  
 Sets the maximum amount of seconds to run each level for.  
 Default: 900 (15 minutes)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoSpecPlayer [true/false]  
-Whether or not the host counts as a player for `autoMinPlayers` when spectating.  
-If false, one more player is required to go to the next level.  
-Default: false  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!settings autoSpecHostIgnored [true/false]  
+When true, the host is ignored in auto mode when counting players.  
+Default: true  
 
 #### Shuffle:
 Permission: __HOST__  
@@ -276,7 +275,7 @@ When the plugin is started for the first time, it generate a setting file that l
 	"autoAdvanceMsg" : "",
 	"autoMinPlayers" : 1,
 	"autoMaxTime" : 900,
-	"autoSpecCountsAsPlayer" : false,
+	"autoSpecHostIgnored" : true,
 	"voteSystemThresholds" : {
 		"skip" : 0.7,
 		"stop" : 0.7,
@@ -316,14 +315,14 @@ __autoMinPlayers__ (number): The minimum amount of players needed for auto mode 
 You can change it with the command !settings autoMinPlayers  
 __autoMaxTime__ (seconds): The maximum amount of time auto mode will spend on one level.  
 You can change it with the command !settings autoMaxTime  
-__autoSpecCountsAsPlayer__ (true/false): Whether or not the host counts towards autoMinPlayers if they are auto-spectating.  
-You can change it with the command !settings autoSpecPlayer  
+__autoSpecHostIgnored__ (true/false): When true, auto mode will ignore the host when counting players. Default true.  
+You can change it with the command !settings autoSpecHostIgnored  
 __voteSystemThresholds__: The vote pass thresholds for each type of vote.  
 You can change them with the command !votectrl [vote type] [new threshold from 0 to 100]  
 When using the !votectrl command, the threshold should be a number, no decimals, from 0 to 100.  
 55 in !votectrl is the same as .55 in the settings file.  
-__win__ (list of string): A list of sentence that will be picked randomly when a player use the command !win  
-__rip__ (list of string) : A list of sentence that will be picked randomly when a player use the command !rip  
+__win__ (list of string): A list of sentence that will be picked randomly when a player uses the command !win  
+__rip__ (list of string) : A list of sentence that will be picked randomly when a player uses the command !rip  
 
 # Author contacts
 Steam : http://steamcommunity.com/id/larnin/  

--- a/Spectrum.Plugins.ServerMod/Spectrum.Plugins.ServerMod.csproj
+++ b/Spectrum.Plugins.ServerMod/Spectrum.Plugins.ServerMod.csproj
@@ -45,6 +45,7 @@
     <Compile Include="cmds\AutoSpecCMD.cs" />
     <Compile Include="cmds\ClearCMD.cs" />
     <Compile Include="cmds\DateCMD.cs" />
+    <Compile Include="cmds\DelsCMD.cs" />
     <Compile Include="cmds\LoadCMD.cs" />
     <Compile Include="cmds\PluginCMD.cs" />
     <Compile Include="cmds\cmd.cs" />
@@ -67,6 +68,8 @@
     <Compile Include="cmds\SpecCMD.cs" />
     <Compile Include="cmds\StartvoteCMD.cs" />
     <Compile Include="cmds\TimelimitCMD.cs" />
+    <Compile Include="cmds\VoteHandler.cs" />
+    <Compile Include="cmds\WelcomeCMD.cs" />
     <Compile Include="cmds\WinCMD.cs" />
     <Compile Include="Entry.cs" />
     <Compile Include="LevelList.cs" />

--- a/Spectrum.Plugins.ServerMod/cmdlist.cs
+++ b/Spectrum.Plugins.ServerMod/cmdlist.cs
@@ -9,12 +9,13 @@ namespace Spectrum.Plugins.ServerMod
 
         public cmdlist()
         {
-            cmds.Add(new AutoCMD());
+            cmds.Add(new AutoCMD(this));
             cmds.Add(new AutoSpecCMD());
             cmds.Add(new ClearCMD());
             cmds.Add(new CountdownCMD());
             cmds.Add(new DateCMD());
             cmds.Add(new DelCMD());
+            cmds.Add(new DelsCMD());
             cmds.Add(new ForceStartCMD());
             cmds.Add(new HelpCMD());
             cmds.Add(new LevelCMD());
@@ -26,6 +27,7 @@ namespace Spectrum.Plugins.ServerMod
             cmds.Add(new PluginCMD());
             cmds.Add(new RestartCMD());
             cmds.Add(new RipCMD());
+            cmds.Add(new WinCMD());
             cmds.Add(new SaveCMD());
             cmds.Add(new ScoresCMD());
             cmds.Add(new ServerCMD());
@@ -33,7 +35,12 @@ namespace Spectrum.Plugins.ServerMod
             cmds.Add(new ShuffleCMD());
             cmds.Add(new SpecCMD());
             cmds.Add(new TimelimitCMD());
-            cmds.Add(new WinCMD());
+            cmds.Add(new WelcomeCMD());
+            
+            VoteHandler voteHandler = new VoteHandler(this);
+            cmds.Add(voteHandler.voteCommand);
+            cmds.Add(voteHandler.voteControlCommand);
+            
         }
 
         public cmd getCommand(string name)

--- a/Spectrum.Plugins.ServerMod/cmdlist.cs
+++ b/Spectrum.Plugins.ServerMod/cmdlist.cs
@@ -27,7 +27,6 @@ namespace Spectrum.Plugins.ServerMod
             cmds.Add(new PluginCMD());
             cmds.Add(new RestartCMD());
             cmds.Add(new RipCMD());
-            cmds.Add(new WinCMD());
             cmds.Add(new SaveCMD());
             cmds.Add(new ScoresCMD());
             cmds.Add(new ServerCMD());
@@ -36,7 +35,8 @@ namespace Spectrum.Plugins.ServerMod
             cmds.Add(new SpecCMD());
             cmds.Add(new TimelimitCMD());
             cmds.Add(new WelcomeCMD());
-            
+            cmds.Add(new WinCMD());
+
             VoteHandler voteHandler = new VoteHandler(this);
             cmds.Add(voteHandler.voteCommand);
             cmds.Add(voteHandler.voteControlCommand);

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -18,10 +18,6 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         const int maxtVoteValue = 3;
 
-        const string msgPattern = @"^\s*msg\s+(.*)\s*$";
-        const string maxPattern = @"^\s*max\s+(\d+)\s*$";
-        const string minPattern = @"^\s*min\s+(\d+)\s*$";
-
         public bool autoMode = false;
         int index = 0;  // Tracks when new levels load. Some code needs to stop running if a new level loads.
         bool voting = false;
@@ -171,7 +167,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
                     {
                         cmd.all.getCommand("shuffle").use(null, "");
                     }
-                    else G.Sys.GameManager_.GoToNextLevel(true);
+                    G.Sys.GameManager_.GoToNextLevel(true);
                 }
                 else autoMode = false;
             }
@@ -302,7 +298,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             yield return new WaitForSeconds(maxRunTime);
             if (currentIndex == index && autoMode)
             {
-                Utilities.sendMessage("This map had run for the maximum run time.");
+                Utilities.sendMessage("This map has run for the maximum run time.");
                 Utilities.sendMessage("Finishing in 30 sec...");
                 int myIndex = index;
                 yield return new WaitForSeconds(30);

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -10,7 +10,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
     class AutoCMD : cmd
     {
         public static bool voteNext = false;
-        public static bool autoSpecCountsAsPlayer = false;
+        public static bool autoSpecHostIgnored = false;
 
         public static string advanceMessage = "";
         public static int maxRunTime = 15*60;
@@ -135,7 +135,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
         {
             AutoSpecCMD autoSpecCommand = (AutoSpecCMD)list.getCommand("autospec");
             // if autoSpec does not count as a player and if the host is autospec, then add 1 to minPlayers
-            return minPlayers + ((!autoSpecCountsAsPlayer && autoSpecCommand.autoSpecMode) ? 1 : 0);
+            return minPlayers + ((!autoSpecHostIgnored && autoSpecCommand.autoSpecMode) ? 1 : 0);
         }
 
         IEnumerable<float> waitForMinPlayers()

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -243,16 +243,21 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         IEnumerator startFromLobby()
         {
+            bool hasRanOnce = false;
             int myIndex;
             int total = 0;
             while (total < 2)
             {
-                Utilities.sendMessage("Starting the game in 10 seconds...");
+                if (hasRanOnce)
+                {
+                    Utilities.sendMessage("Starting the game in 10 seconds...");
 
-                myIndex = index;
-                yield return new WaitForSeconds(10.0f);
-                if (index != myIndex)
-                    yield break;
+                    myIndex = index;
+                    yield return new WaitForSeconds(10.0f);
+                    if (index != myIndex)
+                        yield break;
+                }
+                else hasRanOnce = true;
 
                 foreach (float f in waitForMinPlayers())
                 {

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -213,9 +213,9 @@ namespace Spectrum.Plugins.ServerMod.cmds
                     else Utilities.sendMessage("Level [b][FFFFFF]" + G.Sys.GameManager_.LevelPlaylist_.Playlist_[G.Sys.GameManager_.LevelPlaylist_.Index_ + index].levelNameAndPath_.levelName_ + "[-][/b] selected !");
                     voting = false;
 
-                    myIndex = index;
+                    myIndex = this.index;
                     yield return new WaitForSeconds(5);
-                    if (index != myIndex)
+                    if (this.index != myIndex)
                         yield break;
 
                     if (advanceMessage != "")
@@ -231,7 +231,6 @@ namespace Spectrum.Plugins.ServerMod.cmds
                     else autoMode = false;
                 }
                 else autoMode = false;
-                yield return null;
             }
             else autoMode = false;
             yield return null;

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -134,9 +134,8 @@ namespace Spectrum.Plugins.ServerMod.cmds
             return minPlayers + ((!autoSpecCountsAsPlayer && autoSpecCommand.autoSpecMode) ? 1 : 0);
         }
 
-        IEnumerator waitAndGoNext()
+        IEnumerable<float> waitForMinPlayers()
         {
-            // index and myIndex are used to check if the level advances before auto does it.
             int myIndex;
             if (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
             {
@@ -144,11 +143,20 @@ namespace Spectrum.Plugins.ServerMod.cmds
                 while (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
                 {
                     myIndex = index;
-                    yield return new WaitForSeconds(5.0f);
+                    yield return 5.0f;
                     if (index != myIndex)
                         yield break;
                 }
             }
+        }
+
+        IEnumerator waitAndGoNext()
+        {
+            foreach (float f in waitForMinPlayers())
+            {
+                yield return new WaitForSeconds(f);
+            }
+            int myIndex; // index and myIndex are used to check if the level advances before auto does it.
             if (!Utilities.isOnLobby())
             {
                 Utilities.sendMessage("Going to the next level in 10 seconds...");
@@ -177,18 +185,11 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         IEnumerator voteAndGoNext()
         {
-            int myIndex;
-            if (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+            foreach (float f in waitForMinPlayers())
             {
-                Utilities.sendMessage($"Waiting for there to be {getMinPlayers()} players.");
-                while (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
-                {
-                    myIndex = index;
-                    yield return new WaitForSeconds(5.0f);
-                    if (index != myIndex)
-                        yield break;
-                }
+                yield return new WaitForSeconds(f);
             }
+            int myIndex;
             if (!Utilities.isOnLobby())
             {
                 voting = true;
@@ -242,16 +243,9 @@ namespace Spectrum.Plugins.ServerMod.cmds
             int total = 0;
             while (total < 2)
             {
-                if (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+                foreach (float f in waitForMinPlayers())
                 {
-                    Utilities.sendMessage($"Waiting for there to be {getMinPlayers()} players.");
-                    while (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
-                    {
-                        myIndex = index;
-                        yield return new WaitForSeconds(5.0f);
-                        if (index != myIndex)
-                            yield break;
-                    }
+                    yield return new WaitForSeconds(f);
                 }
                 total = 1;
 

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -10,13 +10,20 @@ namespace Spectrum.Plugins.ServerMod.cmds
     class AutoCMD : cmd
     {
         public static bool voteNext = false;
+        public static bool autoSpecCountsAsPlayer = false;
 
+        public static string advanceMessage = "";
+        public static int maxRunTime = 15*60;
+        public static int minPlayers = 2;
 
-        const int maxRunTime = 15*60;
         const int maxtVoteValue = 3;
 
-        bool autoMode = false;
-        int index = 0;
+        const string msgPattern = @"^\s*msg\s+(.*)\s*$";
+        const string maxPattern = @"^\s*max\s+(\d+)\s*$";
+        const string minPattern = @"^\s*min\s+(\d+)\s*$";
+
+        public bool autoMode = false;
+        int index = 0;  // Tracks when new levels load. Some code needs to stop running if a new level loads.
         bool voting = false;
         Dictionary<string, int> votes = new Dictionary<string, int>();
 
@@ -24,14 +31,20 @@ namespace Spectrum.Plugins.ServerMod.cmds
         public override PermType perm { get { return PermType.HOST; } }
         public override bool canUseAsClient { get { return false; } }
 
-        public AutoCMD()
+        bool didFinish = false;
+
+        cmdlist list;
+
+        public AutoCMD(cmdlist list)
         {
+            this.list = list;
+
             Events.ServerToClient.ModeFinished.Subscribe(data =>
             {
                 onModeFinish();
             });
 
-            Events.GameMode.Go.Subscribe(data =>
+            Events.GameMode.ModeStarted.Subscribe(data =>
             {
                 onModeStart();
             });
@@ -40,30 +53,42 @@ namespace Spectrum.Plugins.ServerMod.cmds
             {
                 onChatEvent(data.message_);
             });
+
+            AutoSpecCMD autoSpecCommand = (AutoSpecCMD)list.getCommand("autospec");
+            CountdownCMD countdownCommand = (CountdownCMD)list.getCommand("countdown");
+            Events.RaceMode.FinalCountdownActivate.Subscribe(data =>
+            {
+                if (G.Sys.PlayerManager_.PlayerList_.Count == 2 && autoSpecCommand.autoSpecMode)
+                {
+                    countdownCommand.stopCountdown();
+                }
+            });
         }
 
         public override void help(ClientPlayerInfo p)
         {
             Utilities.sendMessage("!auto: Toggle the server auto mode.");
-            Utilities.sendMessage("You must have a playlist to active the auto server");
+            Utilities.sendMessage("You must have a playlist to activate the auto server");
+            Utilities.sendMessage("You can change auto mode settings with the !settings command or in the settings file.");
         }
 
         public override void use(ClientPlayerInfo p, string message)
         {
-            if(!autoMode)
+            index++;  // Tracks when new levels load. Some code needs to stop running if a new level loads.
+            if (!autoMode)
             {
                 autoMode = true;
-                Utilities.sendMessage("Automode started !");
-                if(Utilities.isOnLobby())
+                Utilities.sendMessage("Auto mode started!");
+                if (Utilities.isOnLobby())
                     G.Sys.GameManager_.StartCoroutine(startFromLobby());
-                else if(Utilities.isModeFinished())
+                else if (Utilities.isModeFinished())
                     G.Sys.GameManager_.StartCoroutine(waitAndGoNext());
                 else onModeStart();
             }
             else
             {
                 autoMode = false;
-                Utilities.sendMessage("Automode stopped !");
+                Utilities.sendMessage("Auto mode stopped!");
             }
         }
 
@@ -84,12 +109,18 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         private void onModeFinish()
         {
-            if(autoMode)
+            if(autoMode && !didFinish)
             {
-                if (voteNext && G.Sys.GameManager_.LevelPlaylist_.Playlist_.Count >= maxtVoteValue)
-                    G.Sys.GameManager_.StartCoroutine(voteAndGoNext());
-                else G.Sys.GameManager_.StartCoroutine(waitAndGoNext());
+                nextLevel();
             }
+        }
+
+        public void nextLevel()
+        {
+            didFinish = true;
+            if (voteNext && G.Sys.GameManager_.LevelPlaylist_.Playlist_.Count >= maxtVoteValue)
+                G.Sys.GameManager_.StartCoroutine(voteAndGoNext());
+            else G.Sys.GameManager_.StartCoroutine(waitAndGoNext());
         }
 
         private void onModeStart()
@@ -101,20 +132,46 @@ namespace Spectrum.Plugins.ServerMod.cmds
                 G.Sys.GameManager_.StartCoroutine(waitUtilEnd());
         }
 
+        public int getMinPlayers()
+        {
+            AutoSpecCMD autoSpecCommand = (AutoSpecCMD)list.getCommand("autospec");
+            return minPlayers + ((!autoSpecCountsAsPlayer && autoSpecCommand.autoSpecMode) ? 1 : 0);
+        }
+
         IEnumerator waitAndGoNext()
         {
+            // index and myIndex are used to check if the level advances before auto does it.
+            int myIndex;
+            if (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+            {
+                Utilities.sendMessage($"Waiting for there to be {getMinPlayers()} players.");
+                while (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+                {
+                    myIndex = index;
+                    yield return new WaitForSeconds(5.0f);
+                    if (index != myIndex)
+                        yield break;
+                }
+            }
             if (!Utilities.isOnLobby())
             {
-                Utilities.sendMessage("Go to next level in 10 seconds ...");
-                Utilities.sendMessage("Next level is : " + Utilities.getNextLevelName());
+                Utilities.sendMessage("Going to the next level in 10 seconds...");
+                Utilities.sendMessage("Next level is: " + Utilities.getNextLevelName());
+                if (advanceMessage != "")
+                {
+                    Utilities.sendMessage(advanceMessage);
+                }
+                myIndex = index;
                 yield return new WaitForSeconds(10.0f);
+                if (index != myIndex)
+                    yield break;
                 if (autoMode && !Utilities.isOnLobby())
                 {
                     if (Utilities.isCurrentLastLevel())
                     {
                         cmd.all.getCommand("shuffle").use(null, "");
                     }
-                    G.Sys.GameManager_.GoToNextLevel(true);
+                    else G.Sys.GameManager_.GoToNextLevel(true);
                 }
                 else autoMode = false;
             }
@@ -124,6 +181,18 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         IEnumerator voteAndGoNext()
         {
+            int myIndex;
+            if (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+            {
+                Utilities.sendMessage($"Waiting for there to be {getMinPlayers()} players.");
+                while (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+                {
+                    myIndex = index;
+                    yield return new WaitForSeconds(5.0f);
+                    if (index != myIndex)
+                        yield break;
+                }
+            }
             if (!Utilities.isOnLobby())
             {
                 voting = true;
@@ -134,7 +203,11 @@ namespace Spectrum.Plugins.ServerMod.cmds
                 Utilities.sendMessage("[b][FF0000]1[-] : [FFFFFF]" + G.Sys.GameManager_.LevelPlaylist_.Playlist_[G.Sys.GameManager_.LevelPlaylist_.Index_ + 1].levelNameAndPath_.levelName_ + "[-][/b]");
                 Utilities.sendMessage("[b][00FF00]2[-] : [FFFFFF]" + G.Sys.GameManager_.LevelPlaylist_.Playlist_[G.Sys.GameManager_.LevelPlaylist_.Index_ + 2].levelNameAndPath_.levelName_ + "[-][/b]");
                 Utilities.sendMessage("[b][0088FF]3[-] : [FFFFFF]" + G.Sys.GameManager_.LevelPlaylist_.Playlist_[G.Sys.GameManager_.LevelPlaylist_.Index_ + 3].levelNameAndPath_.levelName_ + "[-][/b]");
+
+                myIndex = index;
                 yield return new WaitForSeconds(15);
+                if (index != myIndex)
+                    yield break;
 
                 if (autoMode && !Utilities.isOnLobby())
                 {
@@ -143,8 +216,17 @@ namespace Spectrum.Plugins.ServerMod.cmds
                         Utilities.sendMessage("Restart the current level !");
                     else Utilities.sendMessage("Level [b][FFFFFF]" + G.Sys.GameManager_.LevelPlaylist_.Playlist_[G.Sys.GameManager_.LevelPlaylist_.Index_ + index].levelNameAndPath_.levelName_ + "[-][/b] selected !");
                     voting = false;
-                    yield return new WaitForSeconds(5);
 
+                    myIndex = index;
+                    yield return new WaitForSeconds(5);
+                    if (index != myIndex)
+                        yield break;
+
+                    if (advanceMessage != "")
+                    {
+                        Utilities.sendMessage(advanceMessage);
+                    }
+                        
                     if (autoMode && !Utilities.isOnLobby())
                     {
                         setToNextMap(index);
@@ -161,8 +243,53 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         IEnumerator startFromLobby()
         {
-            Utilities.sendMessage("Start game in 10 seconds ...");
+            int myIndex;
+            int total = 0;
+            while (total < 2)
+            {
+                if (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+                {
+                    Utilities.sendMessage($"Waiting for there to be {getMinPlayers()} players.");
+                    while (G.Sys.PlayerManager_.PlayerList_.Count < getMinPlayers() && autoMode)
+                    {
+                        myIndex = index;
+                        yield return new WaitForSeconds(5.0f);
+                        if (index != myIndex)
+                            yield break;
+                    }
+                }
+                total = 1;
+
+                bool canContinue = false;
+                do
+                {
+                    canContinue = true;
+                    string players = "";
+                    foreach (ClientPlayerInfo current in G.Sys.PlayerManager_.PlayerList_)
+                    {
+                        if (!current.Ready_)
+                        {
+                            canContinue = false;
+                            players += current.Username_ + ", ";
+                        }
+                    }
+                    if (!canContinue)
+                    {
+                        Utilities.sendMessage($"Waiting for all players to be ready. ({players}is not ready.)");
+                        myIndex = index;
+                        yield return new WaitForSeconds(5.0f);
+                        if (index != myIndex)
+                            yield break;
+                        total = 0;
+                    }
+                } while (!canContinue);
+                total = total + 1;
+            }
+            Utilities.sendMessage("Starting the game in 10 seconds...");
+            myIndex = index;
             yield return new WaitForSeconds(10.0f);
+            if (index != myIndex)
+                yield break;
             if (Utilities.isOnLobby())
                 G.Sys.GameManager_.GoToCurrentLevel();
             yield return null;
@@ -170,13 +297,17 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         IEnumerator waitUtilEnd()
         {
+            didFinish = false;
             int currentIndex = index;
             yield return new WaitForSeconds(maxRunTime);
             if (currentIndex == index && autoMode)
             {
-                Utilities.sendMessage("This map had run for 15min ...");
-                Utilities.sendMessage("Finishing in 30 sec ...");
+                Utilities.sendMessage("This map had run for the maximum run time.");
+                Utilities.sendMessage("Finishing in 30 sec...");
+                int myIndex = index;
                 yield return new WaitForSeconds(30);
+                if (index != myIndex)
+                    yield break;
 
                 if (currentIndex == index && autoMode)
                 {

--- a/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoCMD.cs
@@ -14,7 +14,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         public static string advanceMessage = "";
         public static int maxRunTime = 15*60;
-        public static int minPlayers = 2;
+        public static int minPlayers = 1;
 
         const int maxtVoteValue = 3;
 

--- a/Spectrum.Plugins.ServerMod/cmds/AutoSpecCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/AutoSpecCMD.cs
@@ -11,7 +11,9 @@ namespace Spectrum.Plugins.ServerMod.cmds
 {
     class AutoSpecCMD : cmd
     {
-        private bool autoSpecMode = false;
+        public bool autoSpecMode = false;
+
+        public static bool autoSpecReturnToLobby = false;
 
         public override string name { get { return "autospec"; } }
         public override PermType perm { get { return PermType.LOCAL; } }
@@ -58,7 +60,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             var players = G.Sys.PlayerManager_.PlayerList_;
             if (players.Count != 0)
             {
-                if (players.Count == 1 && Utilities.isHost())
+                if (players.Count == 1 && Utilities.isHost() && autoSpecReturnToLobby)
                     G.Sys.GameManager_.GoToLobby();
                 else
                 {

--- a/Spectrum.Plugins.ServerMod/cmds/CountdownCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/CountdownCMD.cs
@@ -79,7 +79,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             countdownEndTime = DateTime.Now.AddSeconds(time);
         }
 
-        private void stopCountdown()
+        public void stopCountdown()
         {
             countdownStarted = false;
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/Spectrum.Plugins.ServerMod/cmds/HelpCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/HelpCMD.cs
@@ -42,15 +42,17 @@ namespace Spectrum.Plugins.ServerMod.cmds
             foreach(var cName in cmd.all.commands())
             {
                 cmd c = cmd.all.getCommand(cName);
-                list += cName;
-                if (c.perm == PermType.HOST)
-                    list += "(H)";
-                if (c.perm == PermType.LOCAL)
-                    list += "(L)";
+                if (c.perm == PermType.HOST && Utilities.isHost())
+                    list += cName+"(H)";
+                if (c.perm == PermType.LOCAL && p.IsLocal_)
+                    list += cName+"(L)";
+                if (c.perm == PermType.ALL)
+                    list += cName;
                 list += ", ";
             }
             Utilities.sendMessage(list.Remove(list.Length - 2));
-            Utilities.sendMessage("(H) = host only / (L) = local client only");
+            if (p.IsLocal_ || Utilities.isHost()) 
+                Utilities.sendMessage("(H) = host only / (L) = local client only");
             Utilities.sendMessage("Use !help <command> for more information on the command");
         }
     }

--- a/Spectrum.Plugins.ServerMod/cmds/HelpCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/HelpCMD.cs
@@ -42,7 +42,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             foreach(var cName in cmd.all.commands())
             {
                 cmd c = cmd.all.getCommand(cName);
-                if (c.perm == PermType.HOST && Utilities.isHost())
+                if (c.perm == PermType.HOST && (p.IsLocal_ && Utilities.isHost()))
                     list += cName+"(H)";
                 if (c.perm == PermType.LOCAL && p.IsLocal_)
                     list += cName+"(L)";

--- a/Spectrum.Plugins.ServerMod/cmds/PlayCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/PlayCMD.cs
@@ -9,6 +9,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
     {
         public static bool playersCanAddMap = false;
         public static bool addOneMapOnly = true;
+        public static bool useVote = false;
 
         public override string name { get { return "play"; } }
         public override PermType perm { get { return playersCanAddMap ? PermType.ALL : PermType.HOST; } }
@@ -16,10 +17,13 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
         public override void help(ClientPlayerInfo p)
         {
-            Utilities.sendMessage("!play [lvl name]: Adds a level to the playlist as the next to be played.");
-            Utilities.sendMessage("!play [filter] : Use filters to find a level");
-            Utilities.sendMessage("Valid filters : -mode -m -name -n -author -a -index -i -last -l -all");
-            Utilities.sendMessage("The level must be know by the server to be show");
+            if (useVote)
+                Utilities.sendMessage("!play [lvl name]: Vote to add a level to the playlist.");
+            else
+                Utilities.sendMessage("!play [lvl name]: Adds a level to the playlist as the next to be played.");
+            Utilities.sendMessage("!play [filter]: Use filters to find a level");
+            Utilities.sendMessage("Valid filters: -mode -m -name -n -author -a -index -i -last -l -all");
+            Utilities.sendMessage("The level must be known by the server to be show up");
         }
 
         public override void use(ClientPlayerInfo p, string message)
@@ -30,15 +34,22 @@ namespace Spectrum.Plugins.ServerMod.cmds
                 return;
             }
 
-            if (Utilities.isOnLobby())
+            if (useVote)  // host can always force play, never uses vote.
             {
-                Utilities.sendMessage("You can't set the next level here");
+                ((VoteHandler.VoteCMD)cmd.all.getCommand("vote")).forceNextUse();
+                ((VoteHandler.VoteCMD)cmd.all.getCommand("vote")).use(p, "y play " + message);
                 return;
             }
 
-            if(G.Sys.GameManager_.ModeID_ == GameModeID.Trackmogrify)
+            if (Utilities.isOnLobby())
             {
-                Utilities.sendMessage("You can't manage the playlist in trackmogrify");
+                Utilities.sendMessage("You can't set the next level in the lobby.");
+                return;
+            }
+
+            if (G.Sys.GameManager_.ModeID_ == GameModeID.Trackmogrify)
+            {
+                Utilities.sendMessage("You can't manage the playlist in trackmogrify.");
                 return;
             }
 

--- a/Spectrum.Plugins.ServerMod/cmds/PlayCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/PlayCMD.cs
@@ -34,7 +34,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
                 return;
             }
 
-            if (useVote)  // host can always force play, never uses vote.
+            if (useVote && !p.IsLocal_)  // host can always force play, never uses vote.
             {
                 ((VoteHandler.VoteCMD)cmd.all.getCommand("vote")).forceNextUse();
                 ((VoteHandler.VoteCMD)cmd.all.getCommand("vote")).use(p, "y play " + message);

--- a/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
@@ -17,6 +17,8 @@ namespace Spectrum.Plugins.ServerMod.cmds
         public override void help(ClientPlayerInfo p)
         {
             Utilities.sendMessage("!settings reload: reload the settings for file.");
+            Utilities.sendMessage("!settings playVote [true/false]: set play command to act as '!vote y play'");
+            Utilities.sendMessage("  This setting overrides the 'play' settings.");
             Utilities.sendMessage("!settings play [true/false]: allow player to add maps on the playlist.");
             Utilities.sendMessage("!settings addOne [true/false]: if enabled, allow the players to add only one map at a time.");
             Utilities.sendMessage("!settings welcome [message]: Set the welcome message.");
@@ -45,6 +47,12 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
             if (strs[0] == "reload")
                 reload(p);
+            else if (strs[0] == "playvote")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else playVote(p, strs[1]);
+            }
             else if (strs[0] == "play")
             {
                 if (strs.Length == 1)
@@ -120,6 +128,27 @@ namespace Spectrum.Plugins.ServerMod.cmds
         {
             Entry.load();
             Utilities.sendMessage("Settings reloaded !");
+        }
+
+        void playVote(ClientPlayerInfo p, string value)
+        {
+            if (value == "0" || value == "false")
+            {
+                PlayCMD.useVote = false;
+                Utilities.sendMessage("'!play' no longer acts as '!vote y play' for non-hosts.");
+            }
+            else if (value == "1" || value == "true")
+            {
+                PlayCMD.useVote = true;
+                Utilities.sendMessage("'!play' now acts as '!vote y play' for non-hosts.");
+            }
+            else
+            {
+                help(p);
+                return;
+            }
+
+            Entry.save();
         }
 
         void play(ClientPlayerInfo p, string value)

--- a/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
@@ -22,7 +22,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             Utilities.sendMessage("!settings welcome [message]: Set the welcome message. \"off\" to disable. %USERNAME% is substituted for the player's name.");
             Utilities.sendMessage("  \"off\" to disable.");
             Utilities.sendMessage("  %USERNAME% is substituted for the player's name.");
-            Utilities.sendMessage("!settings voteSystem [true/false]: Turn the voting system off/on. This is separate from autoVote!");
+            Utilities.sendMessage("!settings voteSystem [true/false]: Turn the voting system off/on.");
             Utilities.sendMessage("  This is separate from autoVote!");
             Utilities.sendMessage("voteSystem thresholds are changed with !votectrl");
             Utilities.sendMessage("-- Setting for !auto: --");

--- a/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
@@ -32,7 +32,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             Utilities.sendMessage("!settings autoMsg [message]: the message to display when advancing the map in auto mode. \"off\" to disable.");
             Utilities.sendMessage("!settings autoMinPlayers [amount]: the minimum amount of players needed for a map to start in auto mode.");
             Utilities.sendMessage("!settings autoMaxTime [seconds]: the maximum amount of time that auto mode will spend on one map.");
-            Utilities.sendMessage("!settings autoSpecPlayer [true/false]: turn on/off whether the host counts as a player for autoMinPlayers when using autospec.");
+            Utilities.sendMessage("!settings autoSpecHostIgnored [true/false]: turn on/off whether the host is ignored as a player when running auto mode.");
         }
 
         public override void use(ClientPlayerInfo p, string message)
@@ -115,7 +115,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
                     help(p);
                 else autoMaxTime(p, strs[1]);
             }
-            else if (strs[0] == "autospecplayer")
+            else if (strs[0] == "autospechostignored")
             {
                 if (strs.Length == 1)
                     help(p);
@@ -306,13 +306,13 @@ namespace Spectrum.Plugins.ServerMod.cmds
         {
             if (value == "0" || value == "false")
             {
-                AutoCMD.autoSpecCountsAsPlayer = false;
-                Utilities.sendMessage("AutoSpec host no longer counts as a player!");
+                AutoCMD.autoSpecHostIgnored = false;
+                Utilities.sendMessage("AutoSpec host is no longer ignored in auto mode!");
             }
             else if (value == "1" || value == "true")
             {
-                AutoCMD.autoSpecCountsAsPlayer = true;
-                Utilities.sendMessage("AutoSpec host counts as a player!");
+                AutoCMD.autoSpecHostIgnored = true;
+                Utilities.sendMessage("AutoSpec host is now ignored in auto mode!");
             }
             else
             {

--- a/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
@@ -19,7 +19,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
             Utilities.sendMessage("!settings reload: reload the settings for file.");
             Utilities.sendMessage("!settings play [true/false]: allow player to add maps on the playlist.");
             Utilities.sendMessage("!settings addOne [true/false]: if enabled, allow the players to add only one map at a time.");
-            Utilities.sendMessage("!settings welcome [message]: Set the welcome message. \"off\" to disable. %USERNAME% is substituted for the player's name.");
+            Utilities.sendMessage("!settings welcome [message]: Set the welcome message.");
             Utilities.sendMessage("  \"off\" to disable.");
             Utilities.sendMessage("  %USERNAME% is substituted for the player's name.");
             Utilities.sendMessage("!settings voteSystem [true/false]: Turn the voting system off/on.");

--- a/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/SettingsCMD.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Spectrum.Plugins.ServerMod.cmds
 {
@@ -11,12 +12,25 @@ namespace Spectrum.Plugins.ServerMod.cmds
         public override PermType perm { get { return PermType.HOST; } }
         public override bool canUseAsClient { get { return false; } }
 
+        private const string msgRegex = @"^\s*\w+ (.*)[\r\n]*$";
+
         public override void help(ClientPlayerInfo p)
         {
             Utilities.sendMessage("!settings reload: reload the settings for file.");
-            Utilities.sendMessage("!settings vote [true/false]: allow players to vote on auto mode.");
             Utilities.sendMessage("!settings play [true/false]: allow player to add maps on the playlist.");
-            Utilities.sendMessage("!settings addOne [true/false] : if enabled, allow the players to add only one map at a time.");
+            Utilities.sendMessage("!settings addOne [true/false]: if enabled, allow the players to add only one map at a time.");
+            Utilities.sendMessage("!settings welcome [message]: Set the welcome message. \"off\" to disable. %USERNAME% is substituted for the player's name.");
+            Utilities.sendMessage("  \"off\" to disable.");
+            Utilities.sendMessage("  %USERNAME% is substituted for the player's name.");
+            Utilities.sendMessage("!settings voteSystem [true/false]: Turn the voting system off/on. This is separate from autoVote!");
+            Utilities.sendMessage("  This is separate from autoVote!");
+            Utilities.sendMessage("voteSystem thresholds are changed with !votectrl");
+            Utilities.sendMessage("-- Setting for !auto: --");
+            Utilities.sendMessage("!settings autoVote [true/false]: allow players to vote on auto mode.");
+            Utilities.sendMessage("!settings autoMsg [message]: the message to display when advancing the map in auto mode. \"off\" to disable.");
+            Utilities.sendMessage("!settings autoMinPlayers [amount]: the minimum amount of players needed for a map to start in auto mode.");
+            Utilities.sendMessage("!settings autoMaxTime [seconds]: the maximum amount of time that auto mode will spend on one map.");
+            Utilities.sendMessage("!settings autoSpecPlayer [true/false]: turn on/off whether the host counts as a player for autoMinPlayers when using autospec.");
         }
 
         public override void use(ClientPlayerInfo p, string message)
@@ -31,12 +45,6 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
             if (strs[0] == "reload")
                 reload(p);
-            else if (strs[0] == "vote")
-            {
-                if (strs.Length == 1)
-                    help(p);
-                else vote(p, strs[1]);
-            }
             else if (strs[0] == "play")
             {
                 if (strs.Length == 1)
@@ -49,6 +57,62 @@ namespace Spectrum.Plugins.ServerMod.cmds
                     help(p);
                 else addOne(p, strs[1]);
             }
+            else if (strs[0] == "welcome")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else
+                {
+                    Match msgMatch = Regex.Match(message, msgRegex);
+                    if (msgMatch.Success)
+                    {
+                        welcome(p, msgMatch.Groups[1].Value);
+                    }
+                }
+            }
+            else if (strs[0] == "votesystem")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else voteSystem(p, strs[1]);
+            }
+            else if (strs[0] == "autovote")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else vote(p, strs[1]);
+            }
+            else if (strs[0] == "automsg")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else
+                {
+                    Match msgMatch = Regex.Match(message, msgRegex);
+                    if (msgMatch.Success)
+                    {
+                        autoMsg(p, msgMatch.Groups[1].Value);
+                    }
+                }
+            }
+            else if (strs[0] == "autominplayers")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else autoMinPlayers(p, strs[1]);
+            }
+            else if (strs[0] == "automaxtime")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else autoMaxTime(p, strs[1]);
+            }
+            else if (strs[0] == "autospecplayer")
+            {
+                if (strs.Length == 1)
+                    help(p);
+                else autoSpecPlayer(p, strs[1]);
+            }
             else help(p);
         }
 
@@ -56,27 +120,6 @@ namespace Spectrum.Plugins.ServerMod.cmds
         {
             Entry.load();
             Utilities.sendMessage("Settings reloaded !");
-        }
-
-        void vote(ClientPlayerInfo p,  string value)
-        {
-            if(value == "0" || value == "false")
-            {
-                AutoCMD.voteNext = false;
-                Utilities.sendMessage("Votes disabled !");
-            }
-            else if(value == "1" || value == "true")
-            {
-                AutoCMD.voteNext = true;
-                Utilities.sendMessage("Votes enabled !");
-            }
-            else
-            {
-                help(p);
-                return;
-            }
-
-            Entry.save();
         }
 
         void play(ClientPlayerInfo p, string value)
@@ -111,6 +154,136 @@ namespace Spectrum.Plugins.ServerMod.cmds
             {
                 PlayCMD.addOneMapOnly = true;
                 Utilities.sendMessage("Players can only add one map now !");
+            }
+            else
+            {
+                help(p);
+                return;
+            }
+
+            Entry.save();
+        }
+
+        void welcome(ClientPlayerInfo p, string value)
+        {
+            if (value == "off")
+            {
+                WelcomeCMD.welcomeMessage = "";
+                Utilities.sendMessage("Welcome message turned off.");
+            }
+            else
+            {
+                WelcomeCMD.welcomeMessage = value;
+                Utilities.sendMessage("Welcome message set.");
+            }
+
+            Entry.save();
+        }
+
+        void voteSystem(ClientPlayerInfo p, string value)
+        {
+            if (value == "0" || value == "false")
+            {
+                VoteHandler.VoteCMD.votesAllowed = false;
+                Utilities.sendMessage("Disabled the voteSystem!");
+            }
+            else if (value == "1" || value == "true")
+            {
+                VoteHandler.VoteCMD.votesAllowed = true;
+                Utilities.sendMessage("Enabled the voteSystem!");
+            }
+            else
+            {
+                help(p);
+                return;
+            }
+
+            Entry.save();
+        }
+
+        void vote(ClientPlayerInfo p, string value)
+        {
+            if (value == "0" || value == "false")
+            {
+                AutoCMD.voteNext = false;
+                Utilities.sendMessage("Votes disabled !");
+            }
+            else if (value == "1" || value == "true")
+            {
+                AutoCMD.voteNext = true;
+                Utilities.sendMessage("Votes enabled !");
+            }
+            else
+            {
+                help(p);
+                return;
+            }
+
+            Entry.save();
+        }
+
+        void autoMsg(ClientPlayerInfo p, string value)
+        {
+            if (value == "off")
+            {
+                AutoCMD.advanceMessage = "";
+                Utilities.sendMessage("Advance message turned off.");
+            }
+            else
+            {
+                AutoCMD.advanceMessage = value;
+                Utilities.sendMessage("Advance message set.");
+            }
+
+            Entry.save();
+        }
+
+        void autoMinPlayers(ClientPlayerInfo p, string value)
+        {
+            int num;
+            if (int.TryParse(value, out num)) {
+                AutoCMD.minPlayers = num;
+                Utilities.sendMessage($"Min players set to {num} !");
+            }
+            else
+            {
+                Utilities.sendMessage("Invalid number!");
+                help(p);
+                return;
+            }
+
+            Entry.save();
+        }
+
+        void autoMaxTime(ClientPlayerInfo p, string value)
+        {
+            int num;
+            if (int.TryParse(value, out num))
+            {
+                AutoCMD.maxRunTime = num;
+                Utilities.sendMessage($"Max time set to {num} !");
+            }
+            else
+            {
+                Utilities.sendMessage("Invalid number!");
+                help(p);
+                return;
+            }
+
+            Entry.save();
+        }
+
+        void autoSpecPlayer(ClientPlayerInfo p, string value)
+        {
+            if (value == "0" || value == "false")
+            {
+                AutoCMD.autoSpecCountsAsPlayer = false;
+                Utilities.sendMessage("AutoSpec host no longer counts as a player!");
+            }
+            else if (value == "1" || value == "true")
+            {
+                AutoCMD.autoSpecCountsAsPlayer = true;
+                Utilities.sendMessage("AutoSpec host counts as a player!");
             }
             else
             {

--- a/Spectrum.Plugins.ServerMod/cmds/VoteHandler.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/VoteHandler.cs
@@ -27,9 +27,9 @@ namespace Spectrum.Plugins.ServerMod.cmds
         {
             this.list = list;
             thresholds = new Dictionary<string, double>();
-            thresholds.Add("skip", 0.5);
-            thresholds.Add("stop", 0.5);
-            thresholds.Add("play", 0.4);
+            thresholds.Add("skip", 0.55);
+            thresholds.Add("stop", 0.55);
+            thresholds.Add("play", 0.55);
             thresholds.Add("kick", 0.7);
             thresholds.Add("count", 0.6);
 

--- a/Spectrum.Plugins.ServerMod/cmds/VoteHandler.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/VoteHandler.cs
@@ -1,0 +1,492 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace Spectrum.Plugins.ServerMod.cmds
+{
+    class VoteHandler
+    {
+
+        private string voteCmdPattern = @"^\s*(\S+)\s+(\S+)\s*(.*)$";
+        private string voteCtrlPattern = @"^\s*(\S+)\s+(\d+)$";
+
+        public static Dictionary<string, double> thresholds = null;
+        private Dictionary<string, List<string>> votes;
+
+        private cmdlist list;
+
+        public VoteCMD voteCommand;
+        public VoteCtrlCMD voteControlCommand;
+
+        public VoteHandler(cmdlist list)
+        {
+            this.list = list;
+            thresholds = new Dictionary<string, double>();
+            thresholds.Add("skip", 0.7);
+            thresholds.Add("stop", 0.7);
+            thresholds.Add("play", 0.55);
+            thresholds.Add("kick", 0.9);
+            thresholds.Add("count", 0.55);
+
+            Entry.load();  // load any existing thresholds
+            Entry.save();  // save any thresholds that were not loaded
+
+            votes = new Dictionary<string, List<string>>();
+            votes.Add("skip", new List<string>());
+            votes.Add("stop", new List<string>());
+            votes.Add("play", new List<string>());
+            votes.Add("kick", new List<string>());
+            votes.Add("count", new List<string>());
+
+            voteCommand = new VoteCMD(this);
+            voteControlCommand = new VoteCtrlCMD(this);
+        }
+
+       public class VoteCtrlCMD : cmd
+        {
+            public override string name { get { return "votectrl"; } }
+            public override PermType perm { get { return PermType.HOST; } }
+            public override bool canUseAsClient { get { return false; } }
+
+            public VoteHandler parent;
+
+            public VoteCtrlCMD(VoteHandler parent)
+            {
+                this.parent = parent;
+            }
+
+            public override void help(ClientPlayerInfo p)
+            {
+                Utilities.sendMessage("!votectrl <voteType> <percent>: Set <percent> as the amount of players needed for a <voteType> vote to succeed.");
+                Utilities.sendMessage("<percent> should be an integer 0 - 100. Set above 100 to disable.");
+            }
+
+            public override void use(ClientPlayerInfo p, string message)
+            {
+                var match = Regex.Match(message, parent.voteCtrlPattern);
+
+                if (!match.Success)
+                {
+                    help(p);
+                    return;
+                }
+
+                string voteType = match.Groups[1].Value.ToLower();
+                string percentS = match.Groups[2].Value;
+                int percent = int.Parse(percentS);
+
+                if (!VoteHandler.thresholds.ContainsKey(voteType))
+                {
+                    Utilities.sendMessage($"Invalid <voteType>. ({voteType})");
+                    help(p);
+                    return;
+                }
+
+                VoteHandler.thresholds[voteType] = Convert.ToDouble(percent) / 100.0;
+                Utilities.sendMessage($"Pass threshold for {voteType} changed to {percent}%");
+            }
+        }
+
+        public class VoteCMD : cmd
+        {
+            public override string name { get { return "vote"; } }
+            public override PermType perm { get { return PermType.ALL; } }
+            public override bool canUseAsClient { get { return false; } }
+
+            public VoteHandler parent;
+
+            public static bool votesAllowed = false;
+
+            private bool votedSkip = false;
+
+            public VoteCMD(VoteHandler parent)
+            {
+                this.parent = parent;
+            }
+
+            public override void help(ClientPlayerInfo p)
+            {
+                Utilities.sendMessage("!vote <yes/no> <voteType> <parameters>: Vote yes/no on the given voteType. y/n also work.");
+                Utilities.sendMessage("!vote <info/i> <voteType>: View information about the voteType.");
+                Utilities.sendMessage("Example: !vote info skip");
+                Utilities.sendMessage("voteTypes:");
+                Utilities.sendMessage(" !vote <y/n> skip: skip the current map.");
+                Utilities.sendMessage(" !vote <y/n> stop: stop the countdown.");
+                Utilities.sendMessage(" !vote <y/n> play <mapName>: vote to play map matching mapName. Use !level to find maps. Uses the same syntax as !level.");
+                /*
+                Utilities.sendMessage(" !vote <y/n> kick <player>: vote to kick <player> from the game.");
+                Utilities.sendMessage(" !vote <y/n> count <time>: vote for <time> to be the new max time.");
+                Utilities.sendMessage("  if <time> is 'off' then the vote is to disable max time.");
+                Utilities.sendMessage("  if <time> is 'bronze'/'silver'/'gold'/'diamond' it is the relevant time for the map.");
+                */
+            }
+
+            public override void use(ClientPlayerInfo p, string message)
+            {
+                if (!votesAllowed)
+                {
+                    Utilities.sendMessage("Votes are disabled.");
+                    return;
+                }
+
+                var match = Regex.Match(message, parent.voteCmdPattern);
+
+                if (!match.Success)
+                {
+                    help(p);
+                    return;
+                }
+
+                string voteValueS = match.Groups[1].Value.ToLower();
+                bool voteValue = false;
+                bool isInfo = false;
+                if (voteValueS == "yes" || voteValueS == "y" || voteValueS == "1" || voteValueS == "true" || voteValueS == "t")
+                {
+                    voteValue = true;
+                }
+                else if (voteValueS == "no" || voteValueS == "n" || voteValueS == "0" || voteValueS == "false" || voteValueS == "f")
+                {
+                    voteValue = false;
+                }
+                else if (voteValueS == "info" || voteValueS == "i")
+                {
+                    isInfo = true;
+                }
+                else
+                {
+                    Utilities.sendMessage("Invalid <yes/no> You can use yes/no, y/n, 1/0, true/false, and t/f.");
+                    return;
+                }
+
+                string voteType = match.Groups[2].Value.ToLower();
+                string parameter = match.Groups[3].Value;
+
+                if (!VoteHandler.thresholds.ContainsKey(voteType))
+                {
+                    Utilities.sendMessage($"Invalid <voteType>. ({voteType})");
+                    help(p);
+                    return;
+                }
+
+                AutoCMD autoCommand = (AutoCMD)parent.list.getCommand("auto");
+                AutoSpecCMD autoSpecCommand = (AutoSpecCMD)parent.list.getCommand("autospec");
+                int playerOffset = (autoCommand.autoMode && autoSpecCommand.autoSpecMode) ? -1 : 0;
+
+                int numPlayers = G.Sys.PlayerManager_.PlayerList_.Count + playerOffset;
+
+                if (isInfo)
+                {
+                    Utilities.sendMessage($"Info for {voteType}:");
+                    Utilities.sendMessage($"Pass threshold: {Convert.ToInt32(Math.Floor(VoteHandler.thresholds[voteType]*100))}%");
+                    int value = parent.votes[voteType].Count;
+                    Utilities.sendMessage($"Votes: {value}/{Convert.ToInt32(Math.Ceiling(VoteHandler.thresholds[voteType] * Convert.ToDouble(numPlayers)))}");
+                    return;
+                }
+
+
+                if (voteType == "skip")
+                {
+                    if (Utilities.isOnLobby())
+                    {
+                        Utilities.sendMessage("You can't vote to skip in the lobby!");
+                        return;
+                    }
+
+                    if (votedSkip)
+                    {
+                        Utilities.sendMessage("Vote skip already succeeded.");
+                        return;
+                    }
+
+                    List<string> votes = parent.votes[voteType];
+
+                    if (votes.Count == 0 && voteValue)
+                    {
+                        Events.ServerToClient.ModeFinished.Subscribe(data =>
+                        {
+                            parent.votes[voteType].Clear();
+                            votedSkip = false;
+                        });
+                    }
+
+                    int value = votes.Count;
+
+                    string playerVoteId = $"{p.Username_}:{p.NetworkPlayer_.externalIP}:{p.NetworkPlayer_.externalPort}";
+                    if (voteValue)
+                    {
+                        if (votes.Contains(playerVoteId))
+                        {
+                            Utilities.sendMessage($"{p.Username_} has already voted to skip {G.Sys.GameManager_.LevelName_}.");
+                            return;
+                        }
+                        votes.Add(playerVoteId);
+                        value = votes.Count;
+                        Utilities.sendMessage($"{p.Username_} voted to skip {G.Sys.GameManager_.LevelName_}.");
+                        Utilities.sendMessage($"Votes: {value}/{Convert.ToInt32(Math.Ceiling(VoteHandler.thresholds[voteType] * Convert.ToDouble(numPlayers)))}");
+                    }
+                    else
+                    {
+                        votes.Remove(playerVoteId);
+                        value = votes.Count;
+                        Utilities.sendMessage($"{p.Username_} unvoted to skip {G.Sys.GameManager_.LevelName_}.");
+                        Utilities.sendMessage($"Votes: {value}/{Convert.ToInt32(Math.Ceiling(VoteHandler.thresholds[voteType] * Convert.ToDouble(numPlayers)))}");
+                        return;
+                    }
+
+
+
+                    if (Convert.ToDouble(value) / Convert.ToDouble(numPlayers) >= VoteHandler.thresholds[voteType])
+                    {
+                        votedSkip = true;
+                        Utilities.sendMessage("Vote skip succeeded! Skipping map...");
+                        parent.advanceLevel();
+                    }
+                }
+                else if (voteType == "stop")
+                {
+                    if (Utilities.isOnLobby())
+                    {
+                        Utilities.sendMessage("You can't vote to stop the countdown in the lobby!");
+                        return;
+                    }
+
+                    List<string> votes = parent.votes[voteType];
+
+                    if (votes.Count == 0 && voteValue)
+                    {
+                        Events.ServerToClient.ModeFinished.Subscribe(data =>
+                        {
+                            parent.votes[voteType].Clear();
+                        });
+                    }
+                    
+                    int value = votes.Count;
+
+                    string playerVoteId = $"{p.Username_}:{p.NetworkPlayer_.externalIP}:{p.NetworkPlayer_.externalPort}";
+                    if (voteValue)
+                    {
+                        if (votes.Contains(playerVoteId))
+                        {
+                            Utilities.sendMessage($"{p.Username_} has already voted to stop the countdown.");
+                            return;
+                        }
+                        votes.Add(playerVoteId);
+                        value = votes.Count;
+                        Utilities.sendMessage($"{p.Username_} voted to stop the countdown.");
+                        Utilities.sendMessage($"Votes: {value}/{Convert.ToInt32(Math.Ceiling(VoteHandler.thresholds[voteType] * Convert.ToDouble(numPlayers)))}");
+                    }
+                    else
+                    {
+                        votes.Remove(playerVoteId);
+                        value = votes.Count;
+                        Utilities.sendMessage($"{p.Username_} unvoted to stop the countdown.");
+                        Utilities.sendMessage($"Votes: {value}/{Convert.ToInt32(Math.Ceiling(VoteHandler.thresholds[voteType] * Convert.ToDouble(numPlayers)))}");
+                        return;
+                    }
+
+                    if (Convert.ToDouble(value) / Convert.ToDouble(numPlayers) >= VoteHandler.thresholds[voteType])
+                    {
+                        parent.votes[voteType].Clear();
+                        CountdownCMD command = (CountdownCMD)parent.list.getCommand("countdown");
+                        command.stopCountdown();
+                        Utilities.sendMessage("Vote stop succeeded! Stopping countdown...");
+                    }
+                }
+                else if (voteType == "play")
+                {
+                    string levelName = parameter;
+                    var m = LevelList.extractModifiers(levelName);
+                    List<LevelPlaylist.ModeAndLevelInfo> lvls = LevelList.levels(m);
+                    List<LevelResultsSortInfo> levelResults = new List<LevelResultsSortInfo>();
+                    
+                    double threshold = VoteHandler.thresholds["play"];
+
+                    LevelPlaylist playlist = new LevelPlaylist();
+                    playlist.Copy(G.Sys.GameManager_.LevelPlaylist_);
+                    var currentPlaylist = playlist.Playlist_;
+                    int index = G.Sys.GameManager_.LevelPlaylist_.Index_;
+
+                    foreach (LevelPlaylist.ModeAndLevelInfo lvl in lvls)
+                    {
+
+                        string id = $"{lvl.mode_}:{lvl.levelNameAndPath_.levelName_}:{lvl.levelNameAndPath_.levelPath_}";
+                        List<string> votes;
+                        if (!parent.votes.TryGetValue(id, out votes))
+                        {
+                            if (voteValue)
+                            {
+                                votes = new List<string>();
+                                parent.votes[id] = votes;
+                            }
+                            else
+                            {
+                                //Utilities.sendMessage($"{p.Username_} unvoted for these maps.");
+                                levelResults.Add(new LevelResultsSortInfo(lvl, 0, numPlayers, threshold, -1));
+                                continue;
+                            }
+                        }
+                        string playerVoteId = $"{p.Username_}:{p.NetworkPlayer_.externalIP}:{p.NetworkPlayer_.externalPort}";
+                        if (!voteValue)
+                        {
+                            votes.Remove(playerVoteId);
+                            if (votes.Count == 0)
+                            {
+                                parent.votes.Remove(id);
+                            }
+                            //Utilities.sendMessage($"{p.Username_} unvoted for these maps.");
+                            levelResults.Add(new LevelResultsSortInfo(lvl, votes.Count, numPlayers, threshold, -1));
+                            continue;
+                        }
+                        else
+                        {
+                            if (votes.Contains(playerVoteId))
+                            {
+                                //Utilities.sendMessage($"{p.Username_} has already voted for these maps.");
+                                levelResults.Add(new LevelResultsSortInfo(lvl, votes.Count, numPlayers, threshold, 0));
+                                //return;
+                                continue;
+                            }
+                            else
+                            {
+                                votes.Add(playerVoteId);
+                                levelResults.Add(new LevelResultsSortInfo(lvl, votes.Count, numPlayers, threshold, 1));
+                                if (Convert.ToDouble(votes.Count) / Convert.ToDouble(numPlayers) >= threshold)
+                                {
+                                    currentPlaylist.Insert(index + 1, lvl);
+                                    parent.votes.Remove(id);
+                                }
+                            }
+                        }
+                    }
+
+                    G.Sys.GameManager_.LevelPlaylist_.Clear();
+                    foreach (var lvl in currentPlaylist)
+                        G.Sys.GameManager_.LevelPlaylist_.Add(lvl);
+                    G.Sys.GameManager_.LevelPlaylist_.SetIndex(index);
+
+                    string newMessage;
+                    int count;
+
+                    newMessage = "";
+                    count = 0;
+                    foreach (LevelResultsSortInfo level in levelResults)
+                    {
+                        if (level.voteState == -1)
+                        {
+                            if (++count <= 10)
+                            {
+                                newMessage = newMessage + level.level.levelNameAndPath_.levelName_ + ", ";
+                            }
+                        }
+                    }
+                    if (count != 0)
+                    {
+                        if (count > 10)
+                        {
+                            Utilities.sendMessage(newMessage + $"and {count - 10} more unvoted.");
+                        }
+                        else
+                        {
+                            Utilities.sendMessage(newMessage + "unvoted.");
+                        }
+                    }
+
+                    newMessage = "";
+                    count = 0;
+                    foreach (LevelResultsSortInfo level in levelResults)
+                    {
+                        if (level.voteState >= 0)
+                        {
+                            if (++count <= 10)
+                            {
+                                newMessage = newMessage + level.level.levelNameAndPath_.levelName_ + ", ";
+                            }
+                        }
+                    }
+                    if (count != 0)
+                    {
+                        if (count > 10)
+                        {
+                            Utilities.sendMessage(newMessage + $"and {count - 10} more voted.");
+                        }
+                        else
+                        {
+                            Utilities.sendMessage(newMessage + "voted.");
+                        }
+                    }
+
+                    newMessage = "";
+                    count = 0;
+                    foreach (LevelResultsSortInfo level in levelResults)
+                    {
+                        if (level.success)
+                        {
+                            if (++count <= 10)
+                            {
+                                newMessage = newMessage + level.level.levelNameAndPath_.levelName_ + ", ";
+                            }
+                        }
+                    }
+                    if (count != 0)
+                    {
+                        if (count > 10)
+                        {
+                            Utilities.sendMessage(newMessage + $"and {count - 10} more added.");
+                        }
+                        else
+                        {
+                            Utilities.sendMessage(newMessage + "added.");
+                        }
+                    }
+                }
+            }
+        }
+
+        class LevelResultsSortInfo
+        {
+            public LevelPlaylist.ModeAndLevelInfo level;
+            public int votes;
+            public bool success;
+            public int voteState;
+            public LevelResultsSortInfo(LevelPlaylist.ModeAndLevelInfo level, int votes, int numPlayers, double threshold, int voteState)
+            {
+                this.level = level;
+                this.votes = votes;
+                success = Convert.ToDouble(votes) / Convert.ToDouble(numPlayers) >= threshold;
+                this.voteState = voteState;
+            }
+        }
+
+        void advanceLevel()
+        {
+            AutoCMD autoCommand = (AutoCMD) list.getCommand("auto");
+            if (autoCommand.autoMode)
+                autoCommand.nextLevel();
+            else G.Sys.GameManager_.StartCoroutine(waitAndGoNext());
+        }
+
+        IEnumerator waitAndGoNext()
+        {
+            if (!Utilities.isOnLobby())
+            {
+                Utilities.sendMessage("Going to the next level in 10 seconds...");
+                Utilities.sendMessage("Next level is : " + Utilities.getNextLevelName());
+                yield return new WaitForSeconds(10.0f);
+                if (!Utilities.isOnLobby())
+                {
+                    if (Utilities.isCurrentLastLevel())
+                    {
+                        G.Sys.GameManager_.GoToLobby();
+                        Utilities.sendMessage("No more levels in the playlist.");
+                    }
+                    else G.Sys.GameManager_.GoToNextLevel(true);
+                }
+            }
+            yield return null;
+        }
+    }
+}

--- a/Spectrum.Plugins.ServerMod/cmds/VoteHandler.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/VoteHandler.cs
@@ -106,6 +106,14 @@ namespace Spectrum.Plugins.ServerMod.cmds
             public VoteCMD(VoteHandler parent)
             {
                 this.parent = parent;
+                
+                Events.ServerToClient.ModeFinished.Subscribe(data =>
+                {
+                    parent.votes["skip"].Clear();
+                    parent.votes["stop"].Clear();
+
+                    votedSkip = false;
+                });
             }
 
             public override void help(ClientPlayerInfo p)
@@ -159,6 +167,7 @@ namespace Spectrum.Plugins.ServerMod.cmds
                 else
                 {
                     Utilities.sendMessage("Invalid <yes/no> You can use yes/no, y/n, 1/0, true/false, and t/f.");
+                    Utilities.sendMessage("You can use info/i to get info.");
                     return;
                 }
 
@@ -204,15 +213,6 @@ namespace Spectrum.Plugins.ServerMod.cmds
 
                     List<string> votes = parent.votes[voteType];
 
-                    if (votes.Count == 0 && voteValue)
-                    {
-                        Events.ServerToClient.ModeFinished.Subscribe(data =>
-                        {
-                            parent.votes[voteType].Clear();
-                            votedSkip = false;
-                        });
-                    }
-
                     int value = votes.Count;
 
                     string playerVoteId = $"{p.Username_}:{p.NetworkPlayer_.externalIP}:{p.NetworkPlayer_.externalPort}";
@@ -255,14 +255,6 @@ namespace Spectrum.Plugins.ServerMod.cmds
                     }
 
                     List<string> votes = parent.votes[voteType];
-
-                    if (votes.Count == 0 && voteValue)
-                    {
-                        Events.ServerToClient.ModeFinished.Subscribe(data =>
-                        {
-                            parent.votes[voteType].Clear();
-                        });
-                    }
                     
                     int value = votes.Count;
 

--- a/Spectrum.Plugins.ServerMod/cmds/WelcomeCMD.cs
+++ b/Spectrum.Plugins.ServerMod/cmds/WelcomeCMD.cs
@@ -1,0 +1,60 @@
+﻿using Events;
+using Events.RaceMode;
+using System;
+using UnityEngine;
+
+namespace Spectrum.Plugins.ServerMod.cmds
+{
+    class WelcomeCMD : cmd
+    {
+        public static string welcomeMessage = "";
+
+        public override string name { get { return "welcome"; } }
+        public override PermType perm { get { return PermType.ALL; } }
+        public override bool canUseAsClient { get { return false; } }
+
+        public WelcomeCMD()
+        {
+
+            Events.Server.StartClientLate.Subscribe(data =>
+            {
+                if (Utilities.isOnline() && Utilities.isHost())
+                    onClientJoin(data.client_);
+            });
+        }
+
+        public override void help(ClientPlayerInfo p)
+        {
+            Utilities.sendMessage("!welcome: Hear the welcome message.");
+            if (Utilities.isHost())
+            {
+                Utilities.sendMessage("You can set the welcome message with !settings");
+            }
+        }
+
+        public override void use(ClientPlayerInfo p, string message)
+        {
+            Utilities.sendMessage(welcomeMessage.Replace("%USERNAME%", p.Username_));
+        }
+
+        
+
+        private void onClientJoin(NetworkPlayer client)
+        {
+            if (welcomeMessage != "")
+            {
+                foreach (ClientPlayerInfo current in G.Sys.PlayerManager_.PlayerList_)
+                {
+                    if (current.NetworkPlayer_ == client)
+                    {
+                        Utilities.sendMessage(welcomeMessage.Replace("%USERNAME%", current.Username_));
+                        return;
+                    }
+                }
+                Utilities.sendMessage(welcomeMessage.Replace("%USERNAME%", "Player"));
+            }
+        }
+
+       
+    }
+}


### PR DESCRIPTION
Additions:
* `!welcome` displays a message to players that enter
* `!vote` allows for voting to skip the map, stop the countdown, and add a level to the playlist
* `!votectrl` allows setting `!vote` vote thresholds
* `!dels` lets one delete multiple levels at once from the playlist

Modifications:
* Update version
* `!auto`
  * Has a minimum players settings
    * Waits for the minimum players before advancing to the next map
  * Has a modifiable maximum run time setting
  * Has a setting to show a message whenever the level advances
  * Has an option to treat an autospec host as if he/she is not there
    * When enabled, autospec host increases minimum players by one
  * If the host is autospec with only two players in the server, the countdown is stopped
  * Allows other commands to advance automode level with `nextLevel`. This is used by `!vote` when skipping if automode is on
  * uses `index` checks throughout to quit part of the auto process if the user advances the level or restarts automode
* `!autospec`
  * Setting to turn on/off the return to lobby behavior when the host is the only player left. For fully automated servers, it's important to stay in the game and wait for other players to join. The `autoMinPlayers` setting will pause automode until enough players have joined. Note: This setting is only changeable in the settings file. I will not be adding it to the settings command until Spectrum works again on Distance stable.
* `!countdown`
  * Allows other commands to stop the countdown. This is used by automode when there's only the autospec host and one other player.
* `!help`
  * Only displays HOST commands to the host.
  * Only displays LOCAL commands to the local player.
  * Doesn't display H/L explanation if no H/L commands are shown.
* `!play`
  * Supports aliasing `!play <map>` to `!vote y play <map>` with `playVote` setting. The host keeps regular functionality.

Settings Additions
* `vote` renamed to `autoVote`, to fit the other new automode settings
* Added `autoMsg`
* Added `autoMinPlayers`
* Added `autoMaxTime`
* Added `autoSpecHostIgnored`: When enabled, the host is ignored when counting players in auto mode.
* Added `voteSystem`: Turns the `!vote` command on/off
* Added `welcome`: Sets the welcome message
* Added `voteSystemThresholds`: Used internally to save the vote system's thresholds. Accessible with `!votectrl`
* Added `playVote`: Turn on/off aliasing of `!play <map>` for `!vote y play <map>` for non-hosts.